### PR TITLE
Fix Buffer deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (source, delimiter, cb) {
   var len = 0
   var buf
 
-  delimiter = typeof delimiter === 'string' ? Buffer(delimiter) : delimiter
+  delimiter = typeof delimiter === 'string' ? Buffer.from(delimiter) : delimiter
 
   source.on('end', onEnd)
   source.on('error', onError)


### PR DESCRIPTION
Calling `Buffer(str)` in node 7 prints:

DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.

---

Thx for this tiny, useful module 👍 
